### PR TITLE
Fixed "no matching distribution" error when installing "wheelhouse"

### DIFF
--- a/hooks/install
+++ b/hooks/install
@@ -15,7 +15,7 @@ if os.path.exists('wheelhouse'):
     # need newer pip, to fix spurious Double Requirement error https://github.com/pypa/pip/issues/56
     check_call(['pip', 'install', '-U', '--no-index', '-f', 'wheelhouse', 'pip'])
     # install the rest of the wheelhouse deps
-    check_call(['pip', 'install', '-U', '--no-index'] + glob('wheelhouse/*'))
+    check_call(['pip', 'install', '-U', '--no-index', '-f', 'wheelhouse'] + glob('wheelhouse/*'))
 
 
 # This will load and run the appropriate @hook and other decorated


### PR DESCRIPTION
Error that came up when testing the fix for juju/charm-tools#58.  I think that it is dependent on the order which the `glob()` returns the files.